### PR TITLE
change metrics port to avoid deployable container startup failuer in …

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -46,8 +46,8 @@ import (
 // Change below variables to serve metrics on different host or port.
 var (
 	metricsHost               = "0.0.0.0"
-	metricsPort         int32 = 8383
-	operatorMetricsPort int32 = 8686
+	metricsPort         int32 = 8385
+	operatorMetricsPort int32 = 8688
 )
 
 func printVersion() {


### PR DESCRIPTION
…the new application pod

Signed-off-by: Xiangjing Li <xilica.ibm.com@xiangjings-mbp.war.can.ibm.com>