### PR TITLE
remove travis sonar scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ jobs:
         - |
           make
           make component/test/unit
-          make sonar/go
     - stage: test-e2e
       name: "Deploy the image to a cluster and run e2e tests"
       if: type = pull_request

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include /opt/build-harness/Makefile.prow
+
 IMG ?= $(shell cat COMPONENT_NAME 2> /dev/null)
 export GOPACKAGES   = $(shell go list ./... | grep -v /manager | grep -v /bindata  | grep -v /vendor | grep -v /internal | grep -v /build | grep -v /test )
 
 .PHONY: build
-
--include /opt/build-harness/Makefile.prow
 
 build:
 	@common/scripts/gobuild.sh build/_output/bin/$(IMG) ./cmd/manager


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

prow is going to take over the sonar scan